### PR TITLE
Fix Process crash when parsing the wrong DB file

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -67,6 +67,9 @@ func newReader(name string, obj interface{}) (*reader, error) {
 	}
 	var meta MetaData
 	metaLength := int(binary.BigEndian.Uint32(body[0:4]))
+	if fileSize <= 4+metaLength {
+		return nil,ErrMetaData
+	}
 	if err := json.Unmarshal(body[4:4+metaLength], &meta); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When we parse the DB file, the wrong DB file metaLength may be
larger than the file size, and illegal address access may occur
when calling 'json.Unmarshal' and be killed by the system.